### PR TITLE
게시글의 댓글 정보를 가져와서 표시하는 페이지 구현

### DIFF
--- a/src/components/ArticleDisplay.jsx
+++ b/src/components/ArticleDisplay.jsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 
 const ArticleDisplay = () => {
   // 테스트용 게시글 아이디
-  const articleId = '6e629508-8e0e-4ea7-b4b8-d9a44f4a8f96';
+  const articleId = 'f1a37c3a-0fdf-46f0-92e1-08739684bf88';
 
   const [article, setArticle] = useState(null);
   const [userNickname, setUserNickname] = useState(null);

--- a/src/components/CommentDisplay.jsx
+++ b/src/components/CommentDisplay.jsx
@@ -1,18 +1,80 @@
+import { useState, useEffect } from 'react';
+import supabase from '../supabase/supabase';
+import dayjs from 'dayjs';
+
 const CommentDisplay = () => {
+  // 테스트용 게시글 아이디
+  const articleId = 'f1a37c3a-0fdf-46f0-92e1-08739684bf88';
+
+  const [comments, setComments] = useState([]);
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // 댓글 정보를 댓글 업데이트 날짜 최신순으로 가져오기
+        const { data: commentsData, error: commentsError } = await supabase
+          .from('Comments')
+          .select('*')
+          .eq('articleId', articleId)
+          .order('updatedAt', { ascending: false });
+        if (commentsError) {
+          throw commentsError;
+        }
+        setComments(commentsData);
+
+        // 댓글 작성자 아이디, 닉네임, 프로필 사진 가져오기
+        if (commentsData.length > 0) {
+          const userIds = [...new Set(commentsData.map((comment) => comment.userId))];
+          const { data: userData, error: userError } = await supabase
+            .from('Users')
+            .select('userId, nickname, imageUrl')
+            .in('userId', userIds);
+          if (userError) {
+            throw userError;
+          }
+
+          const userMap = userData.reduce((acc, user) => {
+            acc[user.userId] = user;
+            return acc;
+          }, {});
+
+          setUsers(userMap);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchData();
+  }, [articleId]);
+
   return (
     <section>
-      <div>
-        <img src="#" alt="프로필 이미지" />
-        {/* 프로필 이미지 */}
-        <div>
-          <div>
-            <span>{/* 닉네임 */}</span>
-            <span>{/* 댓글 작성 날짜 */}</span>
-          </div>
-          <div>{/* 댓글 좋아요 수 */}</div>
-        </div>
-      </div>
-      <div>{/* 댓글 내용 */}</div>
+      <ul>
+        {comments.length === 0 ? (
+          <div>댓글이 존재하지 않습니다.</div>
+        ) : (
+          comments.map((comment) => {
+            // imageUrl가 null인 경우 기본 프로필 이미지 나오도록 나중에 교체할 것
+            const userInfo = users[comment.userId] || { nickname: 'Unknown', imageUrl: '#' };
+            return (
+              <li key={comment.id}>
+                <img src={userInfo.imageUrl} alt="프로필 이미지" />
+                <div>
+                  <span>{userInfo.nickname}</span>
+                  <span>
+                    {comment.createdAt === comment.updatedAt
+                      ? dayjs(comment.createdAt).format('YYYY년 MM월 DD일')
+                      : dayjs(comment.updatedAt).format('YYYY년 MM월 DD일')}
+                  </span>
+                </div>
+                <div>{comment.content}</div>
+              </li>
+            );
+          })
+        )}
+      </ul>
     </section>
   );
 };


### PR DESCRIPTION
- Comments 테이블에서 해당 게시글의 댓글 관련 데이터를 가져와 페이지에 표시하는 기능을 구현했습니다.
- 해당 댓글의 userId 값을 이용해 Users 테이블에서 댓글 작성자 정보를 가져와 페이지에 표시하는 기능을 구현했습니다.